### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://zhaoxiaotong.visualstudio.com/53ef7957-8ed3-4a13-a362-30c9e98a5a4f/2cc9cfea-1ff7-4b4d-9a99-7227e0c608ab/_apis/work/boardbadge/ec7df153-805d-4397-b943-64056e6fb2c7)](https://zhaoxiaotong.visualstudio.com/53ef7957-8ed3-4a13-a362-30c9e98a5a4f/_boards/board/t/2cc9cfea-1ff7-4b4d-9a99-7227e0c608ab/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#18](https://zhaoxiaotong.visualstudio.com/53ef7957-8ed3-4a13-a362-30c9e98a5a4f/_workitems/edit/18). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.